### PR TITLE
Change interface export step 1

### DIFF
--- a/example_1/hardware/include/ros2_control_demo_example_1/rrbot.hpp
+++ b/example_1/hardware/include/ros2_control_demo_example_1/rrbot.hpp
@@ -44,12 +44,6 @@ public:
     const rclcpp_lifecycle::State & previous_state) override;
 
   ROS2_CONTROL_DEMO_EXAMPLE_1_PUBLIC
-  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
-
-  ROS2_CONTROL_DEMO_EXAMPLE_1_PUBLIC
-  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
-
-  ROS2_CONTROL_DEMO_EXAMPLE_1_PUBLIC
   hardware_interface::CallbackReturn on_activate(
     const rclcpp_lifecycle::State & previous_state) override;
 
@@ -70,10 +64,6 @@ private:
   double hw_start_sec_;
   double hw_stop_sec_;
   double hw_slowdown_;
-
-  // Store the command for the simulated robot
-  std::vector<double> hw_commands_;
-  std::vector<double> hw_states_;
 };
 
 }  // namespace ros2_control_demo_example_1

--- a/example_1/hardware/rrbot.cpp
+++ b/example_1/hardware/rrbot.cpp
@@ -40,8 +40,6 @@ hardware_interface::CallbackReturn RRBotSystemPositionOnlyHardware::on_init(
   hw_stop_sec_ = stod(info_.hardware_parameters["example_param_hw_stop_duration_sec"]);
   hw_slowdown_ = stod(info_.hardware_parameters["example_param_hw_slowdown"]);
   // END: This part here is for exemplary purposes - Please do not copy to your production code
-  hw_states_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
-  hw_commands_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
 
   for (const hardware_interface::ComponentInfo & joint : info_.joints)
   {
@@ -103,41 +101,17 @@ hardware_interface::CallbackReturn RRBotSystemPositionOnlyHardware::on_configure
   // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // reset values always when configuring hardware
-  for (uint i = 0; i < hw_states_.size(); i++)
+  for (uint i = 0; i < joint_pos_states_.size(); i++)
   {
-    hw_states_[i] = 0;
-    hw_commands_[i] = 0;
+    joint_pos_states_[i] = 0.0;
   }
-
+  for (uint i = 0; i < joint_pos_commands_.size(); i++)
+  {
+    joint_pos_commands_[i] = 0.0;
+  }
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Successfully configured!");
 
   return hardware_interface::CallbackReturn::SUCCESS;
-}
-
-std::vector<hardware_interface::StateInterface>
-RRBotSystemPositionOnlyHardware::export_state_interfaces()
-{
-  std::vector<hardware_interface::StateInterface> state_interfaces;
-  for (uint i = 0; i < info_.joints.size(); i++)
-  {
-    state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_POSITION, &hw_states_[i]));
-  }
-
-  return state_interfaces;
-}
-
-std::vector<hardware_interface::CommandInterface>
-RRBotSystemPositionOnlyHardware::export_command_interfaces()
-{
-  std::vector<hardware_interface::CommandInterface> command_interfaces;
-  for (uint i = 0; i < info_.joints.size(); i++)
-  {
-    command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_POSITION, &hw_commands_[i]));
-  }
-
-  return command_interfaces;
 }
 
 hardware_interface::CallbackReturn RRBotSystemPositionOnlyHardware::on_activate(
@@ -157,9 +131,9 @@ hardware_interface::CallbackReturn RRBotSystemPositionOnlyHardware::on_activate(
   // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // command and state should be equal when starting
-  for (uint i = 0; i < hw_states_.size(); i++)
+  for (uint i = 0; i < joint_pos_states_.size(); i++)
   {
-    hw_commands_[i] = hw_states_[i];
+    joint_pos_commands_[i] = joint_pos_states_[i];
   }
 
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Successfully activated!");
@@ -194,13 +168,14 @@ hardware_interface::return_type RRBotSystemPositionOnlyHardware::read(
   // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Reading...");
 
-  for (uint i = 0; i < hw_states_.size(); i++)
+  for (uint i = 0; i < joint_pos_states_.size(); i++)
   {
     // Simulate RRBot's movement
-    hw_states_[i] = hw_states_[i] + (hw_commands_[i] - hw_states_[i]) / hw_slowdown_;
+    joint_pos_states_[i] =
+      joint_pos_states_[i] + (joint_pos_commands_[i] - joint_pos_states_[i]) / hw_slowdown_;
     RCLCPP_INFO(
       rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Got state %.5f for joint %d!",
-      hw_states_[i], i);
+      joint_pos_states_[i], i);
   }
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Joints successfully read!");
   // END: This part here is for exemplary purposes - Please do not copy to your production code
@@ -214,12 +189,12 @@ hardware_interface::return_type RRBotSystemPositionOnlyHardware::write(
   // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Writing...");
 
-  for (uint i = 0; i < hw_commands_.size(); i++)
+  for (uint i = 0; i < joint_pos_commands_.size(); i++)
   {
     // Simulate sending commands to the hardware
     RCLCPP_INFO(
       rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Got command %.5f for joint %d!",
-      hw_commands_[i], i);
+      joint_pos_commands_[i], i);
   }
   RCLCPP_INFO(
     rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Joints successfully written!");

--- a/example_1/hardware/rrbot.cpp
+++ b/example_1/hardware/rrbot.cpp
@@ -101,11 +101,11 @@ hardware_interface::CallbackReturn RRBotSystemPositionOnlyHardware::on_configure
   // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // reset values always when configuring hardware
-  for (const auto & descr : joint_states_descriptions_)
+  for (const auto & [name, descr] : joint_state_interfaces_)
   {
     joint_state_set_value(descr, 0.0);
   }
-  for (const auto & descr : joint_commands_descriptions_)
+  for (const auto & [name, descr] : joint_command_interfaces_)
   {
     joint_command_set_value(descr, 0.0);
   }
@@ -131,7 +131,7 @@ hardware_interface::CallbackReturn RRBotSystemPositionOnlyHardware::on_activate(
   // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // command and state should be equal when starting
-  for (const auto & descr : joint_states_descriptions_)
+  for (const auto & [name, descr] : joint_state_interfaces_)
   {
     joint_command_set_value(descr, joint_state_get_value(descr));
   }
@@ -168,7 +168,7 @@ hardware_interface::return_type RRBotSystemPositionOnlyHardware::read(
   // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Reading...");
 
-  for (const auto & descr : joint_states_descriptions_)
+  for (const auto & [name, descr] : joint_state_interfaces_)
   {
     auto new_value = joint_state_get_value(descr) +
                      (joint_command_get_value(descr) - joint_state_get_value(descr)) / hw_slowdown_;
@@ -190,7 +190,7 @@ hardware_interface::return_type RRBotSystemPositionOnlyHardware::write(
   // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Writing...");
 
-  for (const auto & descr : joint_commands_descriptions_)
+  for (const auto & [name, descr] : joint_command_interfaces_)
   {
     // Simulate sending commands to the hardware
     RCLCPP_INFO_STREAM(

--- a/example_1/hardware/rrbot.cpp
+++ b/example_1/hardware/rrbot.cpp
@@ -103,11 +103,11 @@ hardware_interface::CallbackReturn RRBotSystemPositionOnlyHardware::on_configure
   // reset values always when configuring hardware
   for (const auto & [name, descr] : joint_state_interfaces_)
   {
-    joint_state_set_value(descr, 0.0);
+    set_state(name, 0.0);
   }
   for (const auto & [name, descr] : joint_command_interfaces_)
   {
-    joint_command_set_value(descr, 0.0);
+    set_command(name, 0.0);
   }
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Successfully configured!");
 
@@ -133,7 +133,7 @@ hardware_interface::CallbackReturn RRBotSystemPositionOnlyHardware::on_activate(
   // command and state should be equal when starting
   for (const auto & [name, descr] : joint_state_interfaces_)
   {
-    joint_command_set_value(descr, joint_state_get_value(descr));
+    set_command(name, get_state(name));
   }
 
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Successfully activated!");
@@ -170,13 +170,12 @@ hardware_interface::return_type RRBotSystemPositionOnlyHardware::read(
 
   for (const auto & [name, descr] : joint_state_interfaces_)
   {
-    auto new_value = joint_state_get_value(descr) +
-                     (joint_command_get_value(descr) - joint_state_get_value(descr)) / hw_slowdown_;
-    joint_state_set_value(descr, new_value);
+    auto new_value = get_state(name) + (get_command(name) - get_state(name)) / hw_slowdown_;
+    set_state(name, new_value);
     // Simulate RRBot's movement
     RCLCPP_INFO_STREAM(
       rclcpp::get_logger("RRBotSystemPositionOnlyHardware"),
-      "Got state " << joint_state_get_value(descr) << " for joint: " << descr.get_name() << "!");
+      "Got state " << get_state(name) << " for joint: " << name << "!");
   }
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Joints successfully read!");
   // END: This part here is for exemplary purposes - Please do not copy to your production code
@@ -195,7 +194,7 @@ hardware_interface::return_type RRBotSystemPositionOnlyHardware::write(
     // Simulate sending commands to the hardware
     RCLCPP_INFO_STREAM(
       rclcpp::get_logger("RRBotSystemPositionOnlyHardware"),
-      "Got command" << joint_command_get_value(descr) << " for joint: " << descr.get_name() << "!");
+      "Got command" << get_command(name) << " for joint: " << name << "!");
   }
   RCLCPP_INFO(
     rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Joints successfully written!");

--- a/example_1/hardware/rrbot.cpp
+++ b/example_1/hardware/rrbot.cpp
@@ -101,11 +101,11 @@ hardware_interface::CallbackReturn RRBotSystemPositionOnlyHardware::on_configure
   // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // reset values always when configuring hardware
-  for (const auto & descr : joint_states_descr_)
+  for (const auto & descr : joint_states_descriptions_)
   {
     joint_state_set_value(descr, 0.0);
   }
-  for (const auto & descr : joint_commands_descr_)
+  for (const auto & descr : joint_commands_descriptions_)
   {
     joint_command_set_value(descr, 0.0);
   }
@@ -131,7 +131,7 @@ hardware_interface::CallbackReturn RRBotSystemPositionOnlyHardware::on_activate(
   // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // command and state should be equal when starting
-  for (const auto & descr : joint_states_descr_)
+  for (const auto & descr : joint_states_descriptions_)
   {
     joint_command_set_value(descr, joint_state_get_value(descr));
   }
@@ -168,7 +168,7 @@ hardware_interface::return_type RRBotSystemPositionOnlyHardware::read(
   // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Reading...");
 
-  for (const auto & descr : joint_states_descr_)
+  for (const auto & descr : joint_states_descriptions_)
   {
     auto new_value = joint_state_get_value(descr) +
                      (joint_command_get_value(descr) - joint_state_get_value(descr)) / hw_slowdown_;
@@ -190,7 +190,7 @@ hardware_interface::return_type RRBotSystemPositionOnlyHardware::write(
   // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Writing...");
 
-  for (const auto & descr : joint_commands_descr_)
+  for (const auto & descr : joint_commands_descriptions_)
   {
     // Simulate sending commands to the hardware
     RCLCPP_INFO_STREAM(


### PR DESCRIPTION
This showcases for example 1 how the changes proposed in this [PR](https://github.com/StoglRobotics-forks/ros2_control/pull/9) would affect the hardware. The adjusted example has been tested and works with the changes. If you want to test them, first checkout the branch from the before mentioned  [PR](https://github.com/StoglRobotics-forks/ros2_control/pull/9).

The changes are described in more detail in the [PR](https://github.com/StoglRobotics-forks/ros2_control/pull/9):
- Storage for Command-/StateInterface is moved to the SystemInterface -> no local vectors of commads/states
- There is now a default implementation for exportation of the Command-/StateInterfaces -> removed `export_state_interfaces()` and `export_command_interfaces()`
- SystemInterface provides getter/setter methods to update states/read commands. Can either be used with the by passing the `InterfaceDescription` or `state_interface-`/`command_interface-name`



